### PR TITLE
Don't group Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,7 @@ updates:
       interval: monthly
     allow:
       - dependency-type: all
-    groups:
-      python-dependencies:
-        patterns: ['*']
+    open-pull-requests-limit: 20
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
The feature is experimental and it doesn't seem to be doing the right thing in this project. As seen in #8, it's not proposing changes to `pyproject.toml` (the manifest file), only to `poetry.lock` (the lock file), even when there *are* changes to be made in `pyproject.toml`.