### PR TITLE
Better way to specify experimental 3.12 on CI

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -7,15 +7,24 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
+
         python-version:
           - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
-          - '3.12.0-rc.1 - 3.12'
+          - '3.12'
           - 'pypy-3.8'
           - 'pypy-3.9'
+
+        include:
+          - experimental: false
+
+          - python-version: 3.12
+            experimental: true
+
+    continue-on-error: ${{ matrix.experimental }}
 
     runs-on: ${{ matrix.os }}
 
@@ -27,6 +36,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: ${{ matrix.experimental }}
 
       - name: Upgrade PyPA packages
         run: python -m pip install -U pip setuptools wheel

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311, flake8, isort, mypy, pyright
-    3.12.0-rc.1 - 3.12: py312
+    3.12: py312
     pypy-3.8: pypy38
     pypy-3.9: pypy39
 


### PR DESCRIPTION
This lists the version as just 3.12, but uses the `allow-prereleases` key to let setup-python match that to prereleases including the current release candidate.

While I'm at it, I've also set `continue-on-error` for the 3.12 test job, so that it failing won't stop any other jobs from running, since it's more likely to fail for reasons where I would still want to see the output of the other jobs in order to understand if the failure is 3.12-specific.

Both these ways of treating 3.12 specially should be undone sometime after 3.12.0 is out as a stable release, possibly very soon afterward.