### PR TITLE
Revert "Don't group Dependabot version updates (#9)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,9 @@ updates:
       interval: monthly
     allow:
       - dependency-type: all
-    open-pull-requests-limit: 20
+    groups:
+      python-dependencies:
+        patterns: ['*']
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
Now that the feature is stable, let's try this again.

This reverts commit 98a8cbaa1bb0282459a541d6147c2c2929d0a40b.