### PR TITLE
Allow 20 Dependabot PRs even with groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: monthly
     allow:
       - dependency-type: all
+    open-pull-requests-limit: 20
     groups:
       python-dependencies:
         patterns: ['*']


### PR DESCRIPTION
To rule out the limit as a cause of new errors.