### PR TITLE
Fix a bug where a failed workflow could auto-merge

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -144,6 +144,9 @@ jobs:
     needs:
       - tox
 
+    # Don't skip `all-pass` on cancellation, since a skipped required check won't block auto-merge.
+    if: always()
+
     runs-on: ubuntu-latest
 
     steps:

--- a/tests/test_utskip.py
+++ b/tests/test_utskip.py
@@ -62,3 +62,7 @@ def test_skip_if_unavailable_does_not_skip_since_3_8(
 
     with check('The "wrapped" function should be called'):
         wrapped.assert_called_once_with()
+
+
+def test_zzzfail():
+    assert False

--- a/tests/test_utskip.py
+++ b/tests/test_utskip.py
@@ -62,7 +62,3 @@ def test_skip_if_unavailable_does_not_skip_since_3_8(
 
     with check('The "wrapped" function should be called'):
         wrapped.assert_called_once_with()
-
-
-def test_zzzfail():
-    assert False


### PR DESCRIPTION
This fixes a bug where a failed workflow could still auto-merge.