### PR TITLE
Test Python 3.14, and change `macos-13` runner to `macos-15-intel`

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,8 +13,8 @@ jobs:
           - ubuntu-22.04  # For Python 3.7 only (unavailable on >= 24.04).
           - ubuntu-latest
           - ubuntu-24.04-arm
-          - macos-13  # These images are x86-64 (amd64).
-          - macos-15  # These images are Apple Silicon (aarch64, amd64).
+          - macos-15-intel  # These images are x86-64 (amd64).
+          - macos-15  # These images are Apple Silicon (aarch64, arm64).
           - windows-latest
           - windows-11-arm
 
@@ -30,8 +30,10 @@ jobs:
           # TODO: Currently, installing `poetry` on CPython 3.13t (nogil) fails
           # on all platforms when building native code for the `msgpack`
           # dependency, and similarly on some platforms for other dependencies.
-          # Once that is resolved or can be avoided, then add 3.13t.
+          # Once that is resolved or can be avoided, then add 3.13t and 3.14t.
           # - '3.13t'
+          - '3.14'
+          # - '3.14t'
 
           # PyPy
           - 'pypy-3.7'
@@ -54,6 +56,8 @@ jobs:
             python-version: '3.12'
           - os: ubuntu-22.04
             python-version: '3.13'
+          - os: ubuntu-22.04
+            python-version: '3.14'
           - os: ubuntu-22.04
             python-version: 'pypy-3.7'
           - os: ubuntu-22.04
@@ -87,6 +91,15 @@ jobs:
           - os: macos-15
             python-version: 'pypy-3.7'
 
+          # Installing `poetry` fails in PyPy 3.9 on Windows x86-64, with an
+          # error building its `zstandard` dependency. Curiously, this only
+          # happens in PyPy 3.9, and not in earlier or later versions. Probably
+          # an earlier version of `poetry` or one of its dependencies could be
+          # specified in order to avoid this, but for now I just skip PyPy 3.9
+          # on Windows.
+          - os: windows-latest
+            python-version: 'pypy-3.9'
+
           # Only CPython 3.11 and higher are available on Windows 11 arm64.
           - os: windows-11-arm
             python-version: '3.7'
@@ -111,6 +124,8 @@ jobs:
 
         include:
           - experimental: false
+
+      fail-fast: true
 
     continue-on-error: ${{ matrix.experimental }}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
 requires = tox>=4
 env_list =
-    py{37,38,39,310,311,312,313,313t}
+    py{37,38,39,310,311,312,313,313t,314,314t}
     pypy{37,38,39,310,311}
     flake8
     isort
-    mypy-py{37,38,39,310,311,312,313,313t}
+    mypy-py{37,38,39,310,311,312,313,313t,314,314t}
     mypy-pypy{38,39,310,311}  # Omit PyPy 3.7 - `typed-ast` fails to build.
-    pyright-py{37,38,39,310,311,312,313,313t}
+    pyright-py{37,38,39,310,311,312,313,313t,314,314t}
     pyright-pypy{38,39,310,311}  # Omit PyPy 3.7 - `typed-ast` fails to build.
 
 [gh-actions]
@@ -18,8 +18,10 @@ python =
     3.10: py310, mypy-py310, pyright-py310
     3.11: py311, mypy-py311, pyright-py311
     3.12: py312, mypy-py312, pyright-py312
-    3.13: py313, flake8, isort, mypy-py313, pyright-py313
+    3.13: py313, mypy-py313, pyright-py313
     3.13t: py313t, mypy-py313t, pyright-py313t
+    3.14: py314, flake8, isort, mypy-py314, pyright-py314
+    3.14t: py314t, mypy-py314t, pyright-py314t
     pypy-3.7: pypy37
     pypy-3.8: pypy38, mypy-pypy38, pyright-pypy38
     pypy-3.9: pypy39, mypy-pypy39, pyright-pypy39
@@ -38,7 +40,7 @@ commands =
 
 [testenv:flake8]
 description = flake8 lint
-basepython = py313
+basepython = py314
 commands_pre =
     poetry export --only=analyze --output={env_tmp_dir}/requirements.txt
     pip install -qr {env_tmp_dir}/requirements.txt
@@ -47,14 +49,14 @@ commands =
 
 [testenv:isort]
 description = isort check
-basepython = py313
+basepython = py314
 commands_pre =
     poetry export --only=analyze --output={env_tmp_dir}/requirements.txt
     pip install -qr {env_tmp_dir}/requirements.txt
 commands =
     isort --check .
 
-[testenv:mypy-{py37,py38,py39,py310,py311,py312,py313,py313t,pypy37,pypy38,pypy39,pypy310,pypy311}]
+[testenv:mypy-{py37,py38,py39,py310,py311,py312,py313,py313t,py314,py314t,pypy37,pypy38,pypy39,pypy310,pypy311}]
 description = mypy typecheck
 commands_pre =
     poetry export --only=test,analyze --output={env_tmp_dir}/requirements.txt
@@ -62,7 +64,7 @@ commands_pre =
 commands =
     mypy .
 
-[testenv:pyright-{py37,py38,py39,py310,py311,py312,py313,py313t,pypy37,pypy38,pypy39,pypy310,pypy311}]
+[testenv:pyright-{py37,py38,py39,py310,py311,py312,py313,py313t,py314,py314t,pypy37,pypy38,pypy39,pypy310,pypy311}]
 description = pyright typecheck
 commands_pre =
     poetry export --only=test,analyze --output={env_tmp_dir}/requirements.txt


### PR DESCRIPTION
On using `macos-15-intel` instead of `macos-13`, see https://github.com/actions/runner-images/issues/13046.

This should fix the failures that occurred in #89 and #90. This intentionally does not also do the updates that those PR should be able to do once this is merged. This likewise intentionally does not attempt to to have CI test the free-threaded Python 3.13 or the free-threaded Python 3.14, even though one or both of those may be working by now; that can also be put off to its own later PR.

Other changes:

- Disable PyPy 3.9 on Windows, while keeping both earlier and later versions (as well as CPython 3.9). PyPy version 3.9 specifically has started failing when installing `poetry` due to an error while building the `zstandard` dependency whose message indicates it could be solved by installing `setuptools`, but that is already being done. There are various avenues that could be explored to get this working, but for now I just exclude the job. For details on the error, see: https://github.com/EliahKagan/subaudit/actions/runs/20082396227/job/57612320648

- Fix a typo where I had wrongly commented `amd64` as being a synonym of `aarch64`, but had meant `arm64`.

- Set `fail-fast: true` explicitly so it's easy to find where to change it to `fail-fast: false` when needed for debugging.