### PR TITLE
Enable zizmor scanning and make some improvements it recommends

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     groups:
       python:
         patterns: ['*']
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: '/'
@@ -17,3 +19,5 @@ updates:
     groups:
       github-actions:
         patterns: ['*']
+    cooldown:
+      default-days: 7

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -16,17 +16,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
       - name: Check Markdown links
-        uses: tcort/github-action-markdown-link-check@v1
+        uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1.1.2
 
   markdownlint-cli2:
     name: Lint Markdown
     runs-on: ubuntu-latest
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
       - name: Markdown Lint
-        uses: DavidAnson/markdownlint-cli2-action@v22
+        uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101 # v22.0.0
         with:
           globs: '**/*.md'

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -133,10 +133,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: ${{ matrix.experimental }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,21 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0


### PR DESCRIPTION
Changes:

- Enable zizmor, integrating with GitHub Advanced Security.
- Pin actions to full hashes. (For now, even if immutably tagged.)
- Don't persist checkout credentials.
- Use dependency cooldowns (minimum release age), 7 days.

Note that I am not sure if dependency cooldowns are totally effective, because I'm not sure how well they interact with transitive dependency updates in lockfiles.